### PR TITLE
Add redirect support

### DIFF
--- a/lib/context.ts
+++ b/lib/context.ts
@@ -78,6 +78,11 @@ export default class Context {
     return this.#forceSend;
   }
 
+  accepts(type: string) {
+    const accepts = this.headers.get("accept");
+    return accepts.split(",").some((t) => t.includes(type));
+  }
+
   /**
    * Creates an empty response and adds it to Context
    *
@@ -86,6 +91,41 @@ export default class Context {
    */
   sendEmpty = (options: ResponseInit = { headers: {} }) => {
     this.res = new Response(null, options);
+    return this;
+  };
+
+  /**
+   * Creates an empty response with redirect headers and adds it to Context
+   *
+   * @param url The URL to redirect to. Use 'back' to go back to Referrer
+   * @param alt The URL to redirect to if no Referrer
+   * @param options (optional) The Response object options
+   * @returns The Context object with redirect headers
+   */
+  redirect = (
+    url: string,
+    alt?: string,
+    options: ResponseInit = { headers: {} }
+  ) => {
+    if (url === "back") {
+      url = this.req.referrer || alt || "/";
+    }
+
+    if (!options.status) {
+      options.status = 302;
+    }
+
+    options.headers ??= {};
+    options.headers["Location"] = encodeURI(url);
+
+    let body;
+    if (this.accepts("html")) {
+      body = `Redirecting to <a href="${url}">${url}</a>.`;
+    } else if (this.accepts("text")) {
+      body = `Redirecting to ${url}.`;
+    }
+
+    this.res = new Response(body, options);
     return this;
   };
 


### PR DESCRIPTION
Closes #12 

Introduces a `Context.redirect(url, alt, options)` which sets up the proper headers for performing a redirect.

From Koa, passing `back` as the url will attempt to use the `Referrer` header, and fallback to the alt parameter (ex. `Context.redirect('back', '/index.html')`)